### PR TITLE
Add slug, name, and description to font json files

### DIFF
--- a/releases/gutenberg-17.6/collections/google-fonts-with-preview.json
+++ b/releases/gutenberg-17.6/collections/google-fonts-with-preview.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/font-collection.json",
+	"slug": "google-fonts",
+	"name": "Google Fonts",
+	"description": "Install from Google Fonts. Fonts are copied to and served from your site.",
 	"categories": [
 		{
 			"name": "Sans Serif",

--- a/releases/gutenberg-17.6/collections/google-fonts.json
+++ b/releases/gutenberg-17.6/collections/google-fonts.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/font-collection.json",
+	"slug": "google-fonts",
+	"name": "Google Fonts",
+	"description": "Install from Google Fonts. Fonts are copied to and served from your site.",
 	"categories": [
 		{
 			"name": "Sans Serif",

--- a/src/get_google_fonts.js
+++ b/src/get_google_fonts.js
@@ -119,6 +119,9 @@ async function updateFiles() {
 	// The data to be written to the file
 	newData = {
 		$schema: FONT_COLLECTION_SCHEMA_URL,
+		slug: 'google-fonts',
+		name: 'Google Fonts',
+		description: 'Install from Google Fonts. Fonts are copied to and served from your site.',
 		categories,
 		font_families: fontFamilies,
 	};


### PR DESCRIPTION
Adds the slug, name, and description properties to the font collection json files so they contain the complete configuration for the collection.