### PR TITLE
Adds @wordpress prettier config to project

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require( '@wordpress/prettier-config' );


### PR DESCRIPTION
Adds @wordpress prettier config to project so that editor plugins use `@wordpress` prettier settings.

.prettierrc.js is copied from Gutenberg