### PR TITLE
Fix errors when generating font collection

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require( '@wordpress/prettier-config' );

--- a/development-server.js
+++ b/development-server.js
@@ -1,0 +1,55 @@
+const express = require( 'express' );
+const fs = require( 'fs' );
+const http = require( 'http' );
+const morgan = require( 'morgan' );
+const util = require( 'util' );
+const path = require( 'path' );
+const stream = require( 'stream' );
+const pipeline = util.promisify( stream.pipeline );
+const app = express();
+
+// Use morgan middleware for logging
+app.use( morgan( 'combined' ) );
+
+app.get( '/images/fonts/*', async ( req, res ) => {
+	const filePath = path.join(
+		__dirname,
+		'releases',
+		'gutenberg-' + req.params[ 0 ]
+	);
+	if ( path.extname( filePath ) === '.json' ) {
+		const readStream = fs.createReadStream( filePath, {
+			encoding: 'utf8',
+		} );
+		const transformStream = new stream.Transform( {
+			transform( chunk, encoding, callback ) {
+				this.push(
+					chunk
+						.toString()
+						.replaceAll(
+							'https://s.w.org/images/fonts',
+							'http://localhost:9158/images/fonts'
+						)
+				);
+				callback();
+			},
+		} );
+
+		readStream.on( 'error', ( err ) => {
+			res.status( 404 ).send( `File not found: ${ filePath }` );
+		} );
+
+		res.setHeader( 'Content-Type', 'application/json' );
+		await pipeline( readStream, transformStream, res );
+	} else {
+		res.sendFile( filePath, ( err ) => {
+			if ( err ) {
+				res.status( 404 ).send( `File not found: ${ filePath }` );
+			}
+		} );
+	}
+} );
+
+http.createServer( app ).listen( 9158, () => {
+	console.log( 'HTTP Server running at http://localhost:9158' );
+} );

--- a/development-server.js
+++ b/development-server.js
@@ -12,15 +12,21 @@ const app = express();
 app.use( morgan( 'combined' ) );
 
 app.get( '/images/fonts/*', async ( req, res ) => {
+	// Serve font collections from the local filesystem at the same url paths as s.w.org for both WP and Gutenberg releases:
+	// e.g. /images/fonts/wp-6.5/... and /images/fonts/17.7/...
+	const subdir = req.url.includes( '/wp-' ) ? '' : 'gutenberg-';
 	const filePath = path.join(
 		__dirname,
 		'releases',
-		'gutenberg-' + req.params[ 0 ]
+		subdir + req.params[ 0 ]
 	);
+
+	// Rewrite font preview URLs in the collection JSON to use the development server
 	if ( path.extname( filePath ) === '.json' ) {
 		const readStream = fs.createReadStream( filePath, {
 			encoding: 'utf8',
 		} );
+
 		const transformStream = new stream.Transform( {
 			transform( chunk, encoding, callback ) {
 				this.push(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/scripts": "^26.19.0",
+				"express": "^4.19.2",
+				"http": "^0.0.1-security",
+				"morgan": "^1.10.0",
 				"text-to-svg": "^3.1.5",
 				"woff2": "^1.0.0"
 			}
@@ -5146,6 +5149,22 @@
 				}
 			]
 		},
+		"node_modules/basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"dependencies": {
+				"safe-buffer": "5.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/basic-auth/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
 		"node_modules/basic-ftp": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
@@ -5194,12 +5213,12 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"dependencies": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -5207,7 +5226,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -8072,16 +8091,16 @@
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA=="
 		},
 		"node_modules/express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
+				"body-parser": "1.20.2",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
+				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -8113,9 +8132,9 @@
 			}
 		},
 		"node_modules/express/node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -9127,6 +9146,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/http": {
+			"version": "0.0.1-security",
+			"resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+			"integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
 		},
 		"node_modules/http-deceiver": {
 			"version": "1.2.7",
@@ -11779,6 +11803,45 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
+		"node_modules/morgan": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+			"dependencies": {
+				"basic-auth": "~2.0.1",
+				"debug": "2.6.9",
+				"depd": "~2.0.0",
+				"on-finished": "~2.3.0",
+				"on-headers": "~1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/morgan/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/morgan/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+		},
+		"node_modules/morgan/node_modules/on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/mrmime": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -13732,9 +13795,9 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",
@@ -20713,6 +20776,21 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
+		"basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"basic-ftp": {
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
@@ -20752,12 +20830,12 @@
 			}
 		},
 		"body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
 			"requires": {
 				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
+				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
@@ -20765,7 +20843,7 @@
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
 				"qs": "6.11.0",
-				"raw-body": "2.5.1",
+				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
 			},
@@ -22833,16 +22911,16 @@
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA=="
 		},
 		"express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
 			"requires": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
+				"body-parser": "1.20.2",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
+				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -22871,9 +22949,9 @@
 			},
 			"dependencies": {
 				"cookie": {
-					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-					"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+					"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
 				},
 				"debug": {
 					"version": "2.6.9",
@@ -23616,6 +23694,11 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
 			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="
+		},
+		"http": {
+			"version": "0.0.1-security",
+			"resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
+			"integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
@@ -25551,6 +25634,41 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
+		"morgan": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+			"integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+			"requires": {
+				"basic-auth": "~2.0.1",
+				"debug": "2.6.9",
+				"depd": "~2.0.0",
+				"on-finished": "~2.3.0",
+				"on-headers": "~1.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+				},
+				"on-finished": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+					"integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+					"requires": {
+						"ee-first": "1.1.1"
+					}
+				}
+			}
+		},
 		"mrmime": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
@@ -26869,9 +26987,9 @@
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
 		},
 		"raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
 			"requires": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"lint:js": "wp-scripts lint-js",
 		"lint:md:docs": "wp-scripts lint-md-docs",
 		"lint:pkg-json": "wp-scripts lint-pkg-json",
-		"packages-update": "wp-scripts packages-update"
+		"packages-update": "wp-scripts packages-update",
+		"serve": "node development-server.js"
 	},
 	"repository": {
 		"type": "git",
@@ -25,6 +26,9 @@
 	"homepage": "https://github.com/matiasbenedetto/google-fonts-to-wordpress-collection#readme",
 	"dependencies": {
 		"@wordpress/scripts": "^26.19.0",
+		"express": "^4.19.2",
+		"http": "^0.0.1-security",
+		"morgan": "^1.10.0",
 		"text-to-svg": "^3.1.5",
 		"woff2": "^1.0.0"
 	}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 // Google Fonts API constants
 const API_URL =
-	'https://www.googleapis.com/webfonts/v1/webfonts?&key=';
+	'https://www.googleapis.com/webfonts/v1/webfonts?sort=popularity&key=';
 const API_KEY = process.env.GOOGLE_FONTS_API_KEY;
 const GOOGLE_FONTS_CAPABILITY = '&capability=WOFF2';
 
@@ -10,14 +10,14 @@ const PREVIEWS_FOLDER = 'previews';
 const COLLECTIONS_FOLDER = 'collections';
 const GOOGLE_FONTS_FILE = 'google-fonts.json';
 const GOOGLE_FONTS_WITH_PREVIEWS_FILE = 'google-fonts-with-preview.json';
-const SVG_PREVIEWS_BASE_URL = 'https://s.w.org/images/fonts/17.7/previews/';
+const SVG_PREVIEWS_BASE_URL = 'https://s.w.org/images/fonts/18.2/previews/';
 
 // font-collection.json schema realted constants
 const FONT_COLLECTION_SCHEMA_URL =
 	'https://schemas.wp.org/trunk/font-collection.json';
 
 // Current Release
-const CURRENT_RELEASE = 'gutenberg-17.7';
+const CURRENT_RELEASE = 'gutenberg-18.2';
 
 module.exports = {
 	API_URL,

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ async function downloadFile( url, destPath ) {
 			} )
 			.on( 'error', function ( err ) {
 				// Handle errors
-				fs.unlink( tempPath ); // Delete the file async. (But we don't check the result)
+				fs.unlink( tempPath, () => {} ); // Delete the file async. (But we don't check the result)
 				reject( err.message );
 			} );
 	} );


### PR DESCRIPTION
This PR stages the changes needed to re-generate the font collection without errors:

- Fixes lack of callback function in error handler
- Renames downloaded font files to prevent `ENAMETOOLONG: name too long` errors

It does not yet add the regenerated collection, as we'll need to resolve https://github.com/WordPress/google-fonts-to-wordpress-collection/issues/27 before we can do that.