### PR TITLE
Fix format:json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"files": "node src/download_google_font_assets.js",
 		"previews": "node src/generate_font_previews.js && npm run format:json",
 		"format": "wp-scripts format",
-		"format:json": "wp-scripts format releases/**/*.json",
+		"format:json": "wp-scripts format \"releases/**/*.json\"",
 		"lint": "npm run lint:js && npm run lint:md-docs && npm run lint:pkg-json",
 		"lint:js": "wp-scripts lint-js",
 		"lint:md-docs": "wp-scripts lint-md-docs",


### PR DESCRIPTION
I noticed that when I ran the `format:json` command, only some of the JSON files in the `releases` directory were formatted.

I was able to reproduce this issue on Windows with WSL2 (Linux). I would be happy if you could confirm that you can reproduce this issue on Mac OS and that this PR solves the problem.

I don't know the root cause, but it seems that by explicitly wrapping the format path in double quotes, all JSON files can be found.

### Before

```
npm run format:json

> google-fonts-to-wordpress-collection@0.0.1 format:json
> wp-scripts format releases/**/*.json

releases/gutenberg-16.7/google-fonts-with-preview.json 458ms
releases/gutenberg-16.7/google-fonts-with-previews.json 398ms
releases/gutenberg-16.7/google-fonts.json 325ms
```

As you can see, only JSON files in the `releases/gutenberg-16.7` directory will be formatted.

### After

```
npm run format:json

> google-fonts-to-wordpress-collection@0.0.1 format:json
> wp-scripts format "releases/**/*.json"

releases/gutenberg-16.7/google-fonts-with-preview.json 451ms
releases/gutenberg-16.7/google-fonts-with-previews.json 384ms
releases/gutenberg-16.7/google-fonts.json 317ms
releases/gutenberg-17.6/collections/google-fonts-with-preview.json 385ms
releases/gutenberg-17.6/collections/google-fonts.json 337ms
releases/gutenberg-17.7/collections/google-fonts-with-preview.json 383ms
releases/gutenberg-17.7/collections/google-fonts.json 312ms
releases/wp-6.5/collections/google-fonts-with-preview.json 388ms
releases/wp-6.5/collections/google-fonts.json 334ms
```

~~This PR replaces space indentation with tab indentation in one file (`releases/gutenberg-17.7/collections/google-fonts-with-preview.json`). No fonts will be added, updated or removed.~~