### PR TITLE
Stringify Google Fonts JSON string with tab formatting

### DIFF
--- a/src/get_google_fonts.js
+++ b/src/get_google_fonts.js
@@ -15,7 +15,7 @@ const {
 	COLLECTIONS_FOLDER,
 	FONT_COLLECTION_SCHEMA_URL,
 } = require( './constants' );
-const { releasePath } = require( './utils' );
+const { releasePath, stringify } = require( './utils' );
 
 function formatCategoryName( slug ) {
 	return (
@@ -122,7 +122,7 @@ async function updateFiles() {
 	};
 
 	if ( response.items ) {
-		const newDataString = JSON.stringify( newData, null, '\t' );
+		const newDataString = stringify( newData );
 
 		// If the file doesn't exist, create it
 		if (
@@ -141,7 +141,7 @@ async function updateFiles() {
 			'utf8'
 		);
 		const oldData = JSON.parse( oldFileData );
-		const oldDataString = JSON.stringify( oldData, null, '\t' );
+		const oldDataString = stringify( oldData );
 
 		if (
 			calculateHash( newDataString ) !== calculateHash( oldDataString )

--- a/src/get_google_fonts.js
+++ b/src/get_google_fonts.js
@@ -122,7 +122,7 @@ async function updateFiles() {
 	};
 
 	if ( response.items ) {
-		const newDataString = JSON.stringify( newData, null, 2 );
+		const newDataString = JSON.stringify( newData, null, '\t' );
 
 		// If the file doesn't exist, create it
 		if (
@@ -141,7 +141,7 @@ async function updateFiles() {
 			'utf8'
 		);
 		const oldData = JSON.parse( oldFileData );
-		const oldDataString = JSON.stringify( oldData, null, 2 );
+		const oldDataString = JSON.stringify( oldData, null, '\t' );
 
 		if (
 			calculateHash( newDataString ) !== calculateHash( oldDataString )

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,16 @@ async function downloadFile( url, destPath ) {
 	} );
 }
 
+function stringify( data ) {
+	return (
+		JSON.stringify( data, null, '\t' )
+			// make single element arrays to take only one line
+			.replace( /\[\n\t+(".*?")\n\t+\]/g, '[ $1 ]' )
+	);
+}
+
 module.exports = {
 	releasePath,
 	downloadFile,
+	stringify,
 };


### PR DESCRIPTION
Preparation for moving forward with #34

To update Google fonts, we run the following command:

```
GOOGLE_FONTS_API_KEY={YOUR_API_KEY} npm run api
```

Currently, when we run this command, the `releases/gutenberg-17.7/collections/google-fonts.json` file is updated, but because tab indents are replaced with space indents, it can be difficult to know which fonts have been newly added even when we run `git diff`.

### Testing Instructions

Run the following commands:

```
GOOGLE_FONTS_API_KEY={YOUR_API_KEY} npm run API
git diff
```

- trunk: The entire file is assumed to have been updated, making it difficult to know what has changed.
- This PR: The difference should be small. There is a difference in the category field, but this is just a line break change, not a category value change. Example:
  ```diff
                          },
  -                       "categories": [ "display" ]
  +                       "categories": [
  +                               "display"
  +                       ]
                  },
  ```
  In a follow-up, we can fix this line break difference and it will be easier to see the newly added fonts.