### PR TITLE
Fix development server route

### DIFF
--- a/development-server.js
+++ b/development-server.js
@@ -11,15 +11,14 @@ const app = express();
 // Use morgan middleware for logging
 app.use( morgan( 'combined' ) );
 
-app.get( '/images/fonts/*', async ( req, res ) => {
+app.get( '/images/fonts/*path', async ( req, res ) => {
 	// Serve font collections from the local filesystem at the same url paths as s.w.org for both WP and Gutenberg releases:
 	// e.g. /images/fonts/wp-6.5/... and /images/fonts/17.7/...
 	const subdir = req.url.includes( '/wp-' ) ? '' : 'gutenberg-';
-	const filePath = path.join(
-		__dirname,
-		'releases',
-		subdir + req.params[ 0 ]
-	);
+	const pathSegment = Array.isArray( req.params.path )
+		? req.params.path.join( '/' )
+		: req.params.path;
+	const filePath = path.join( __dirname, 'releases', subdir + pathSegment );
 
 	// Rewrite font preview URLs in the collection JSON to use the development server
 	if ( path.extname( filePath ) === '.json' ) {

--- a/development-server.js
+++ b/development-server.js
@@ -15,9 +15,7 @@ app.get( '/images/fonts/*path', async ( req, res ) => {
 	// Serve font collections from the local filesystem at the same url paths as s.w.org for both WP and Gutenberg releases:
 	// e.g. /images/fonts/wp-6.5/... and /images/fonts/17.7/...
 	const subdir = req.url.includes( '/wp-' ) ? '' : 'gutenberg-';
-	const pathSegment = Array.isArray( req.params.path )
-		? req.params.path.join( '/' )
-		: req.params.path;
+	const pathSegment = req.params.path.join( '/' );
 	const filePath = path.join( __dirname, 'releases', subdir + pathSegment );
 
 	// Rewrite font preview URLs in the collection JSON to use the development server


### PR DESCRIPTION
We updated `express` in #47. The way paths are provided has changed on the development server, so we will fix this.

### How to test

- Run `npm run serve`
- Confirm that you can access the following URL: ``http://localhost:9158/images/fonts/wp-7.0/collections/google-fonts-with-preview.json`