### PR TITLE
Improve documentation for new font collection releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ New releases added via PR can be tested on a local site. To serve the fonts from
 npm run serve
 ```
 
-Add the following filters to an mu-plugin running on your local WordPress site (e.g. `wp-content/mu-plugins/0-local.php`). These codes register a new font collection based on the new fonts served from the development server and grant it access to the development server.
+Add the following filters to an mu-plugin running on your local WordPress site (e.g. `wp-content/mu-plugins/0-local.php`). This will register a new font collection based on the new fonts served from the development server and grant it access to the development server.
 
 Note that you need to update the `$fonts_version` with the new version. e.g. For WordPress 7.0, `$fonts_version` should be `wp-7.0`.
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,31 @@ The generated JSON files are deployed to the w.org CDN and consumed by the Font 
 
 Here are examples of the JSON files these scripts generate:
 
-- <https://s.w.org/images/fonts/17.7/collections/google-fonts.json>
-- <https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json>
+-   <https://s.w.org/images/fonts/17.7/collections/google-fonts.json>
+-   <https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json>
 
-## How?
+## What is the purpose of this repo?
 
 The code in this repo:
 
-- Gets a copy of the list of fonts provided by Google Fonts API.
-- Transforms the list provided by Google Fonts API into a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections.
-- Downloads each one of the font assets for the 1500+ families available.
-- Uses the font face downloaded assets to generate SVG format images with the font previews.
-- Generates a new JSON file, including the preview images link.
+-   Gets a copy of the list of fonts provided by Google Fonts API.
+-   Transforms the list provided by Google Fonts API into a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections.
+-   Downloads each one of the font assets for the 1500+ families available.
+-   Uses the font face downloaded assets to generate SVG format images with the font previews.
+-   Generates a new JSON file, including the preview images link.
 
-The generated JSON files are then deployed to the w.org CDN through a Meta Trac ticket when necessary. The [7808 ticket](https://meta.trac.wordpress.org/ticket/7808) is an example of this for the WordPress 6.7 release.
+## Requirements
 
-## Instructions
+-   NodeJS 22+
+-   A Google Fonts API key: Create a key on [the credentials page](https://console.cloud.google.com/apis/credentials).
+
+## How to setup
+
+This repository is quite large, so when cloning it locally, we recommend using a shallow clone with the `--depth=1` option:
+
+```bash
+git clone --depth=1 https://github.com/WordPress/google-fonts-to-wordpress-collection.git
+```
 
 Install the NPM dependencies:
 
@@ -29,73 +38,101 @@ Install the NPM dependencies:
 npm install
 ```
 
----
+## Creating a new version of the font collection
+
+To host a new font collection for the Font Library in alignment with a WordPress major release, please follow the steps below:
+
+### 1. Create a core ticket
+
+Create a tracking ticket to manage various tasks. The [64564 ticket](https://core.trac.wordpress.org/ticket/64564) is an example of this for the WordPress 7.0 release.
+
+### 2. Set the new release version
+
+First, Update the `CURRENT_RELEASE` and `SVG_PREVIEWS_BASE_URL` constants in `src/constant.js` with the new release version. e.g. For WordPress 7.0, `const CURRENT_RELEASE = 'wp-7.0'` and `const SVG_PREVIEWS_BASE_URL = 'https://s.w.org/images/fonts/wp-7.0/previews/'`.
+
+### 3. Fetch Google Fonts Data
+
+Fetches font data from the Google Fonts API and converts it to a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections. Create a Google API key on [the credentials page](https://console.cloud.google.com/apis/credentials) and set it as the `GOOGLE_FONTS_API_KEY` environment variable:
 
 ```bash
-GOOGLE_FONTS_API_KEY=abc123 npm run api
+GOOGLE_FONTS_API_KEY={YOUR_GOOGLE_FONTS_API_KEY} npm run api
 ```
 
-- Gets a copy of the list of fonts provided by Google Fonts API.
-- Transforms the list provided by Google Fonts API into a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections.
+On Windows (PowerShell), set the environment variable and run the command as follows:
 
----
+```powershell
+$env:GOOGLE_FONTS_API_KEY = "{YOUR_GOOGLE_FONTS_API_KEY}"; npm run api
+```
+
+This script will create a new `releases/{wp-X.X}/collections/google-fonts.json` file.
+
+**Note: Never expose your Google API key publicly or commit it to this repository.**
+
+### 4. Generate SVG Previews for Google Fonts
+
+Generates SVG preview images for each font family and font face from the Google Fonts collection. The script iterates over the list of font families, downloads the font assets, uses them to generate SVG preview images, and creates a new JSON file with preview image links. The updated JSON file is saved as `releases/{wp-X.X}/collections/google-fonts-with-preview.json`.
 
 ```bash
 npm run previews
 ```
 
-- Iterates over the list of font families and for each one:
-- Downloads the font family assets.
-- Uses the font face downloaded assets to generate SVG format images with the font previews.
-- Generates a new JSON file, including the preview images link.
+Note that this command may take some time, as it generates a large number of font previews.
 
-### Development server
+If the font preview fails to generate due to a possibly corrupted font, consider adding the file to the `excludedFontFamilies` variable defined in the `src/generate_font_previews.js` file.
 
-To serve the fonts from a development server for testing on a local WordPress site:
+### 5. Create a PR
 
-Start the development server from this repo
+Now you're ready to create a pull request. The modified files/directory should look like this, commit them, and submit the PR:
+
+-   Modifiled:
+    -   `src/constants.js`
+-   Created:
+    -   `releases/{wp-X.X}/collections/google-fonts.json`
+    -   `releases/{wp-X.X}/collections/google-fonts-with-preview.json`
+    -   `releases/{wp-X.X}/previews/*`
+
+Note that `releases/{wp-X.X}/font-assets/*` is gitignored. The ~font-assets` directory contains intermediate files used only for generating SVG previews.
+
+### 6. Test the PR
+
+New releases added via PR can be tested on a local site. To serve the fonts from a development server for testing on a local WordPress site, start the development server from this repo. e.g. For WordPress 7.0, you can check the fonts served with `http://localhost:9158/images/fonts/wp-7.0/collections/google-fonts-with-preview.json`:
 
 ```bash
 npm run serve
 ```
 
-Add the following filters to an mu-plugin running on your local WordPress site (e.g. `wp-content/mu-plugins/0-local.php`). Update the version variables, if needed:
+Add the following filters to an mu-plugin running on your local WordPress site (e.g. `wp-content/mu-plugins/0-local.php`). These codes register a new font collection based on the new fonts served from the development server and grant it access to the development server.
 
--   `$wp_release_fonts_version` version in the collection url your local site is running
-    - Check `wp_register_font_collection` in `wp-includes/fonts.php`
-    - e.g. A `font_families` url of `https://s.w.org/images/fonts/wp-6.5/collections/google-fonts-with-preview.json` means a `$wp_release_fonts_version` of `6.5`
--   `$gutenberg_release_fonts_version` version of the collection url from Gutenberg (if Gutenberg is loading a newer version of the collection)
-    - Check for `wp_register_font_collection( 'google-fonts', ...)` [in the Gutenberg repo](https://github.com/search?q=repo:WordPress/gutenberg+wp_register_font_collection(+'google-fonts'&type=code)
-)
-    - e.g. A `font_families` url of `https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json` means a `$gutenberg_release_fonts_version` of `17.7`
--   `$generated_fonts_version` version of fonts generated in this repo you would like to serve
-    - e.g if the fonts are in a folder `releases/gutenberg-18.2`, the `$generated_fonts_version` should be `18.2`
-    - For fonts in `releases/wp-6.6`, `$generated_fonts_version` should be `6.6`
+Note that you need to update the `$fonts_version` with the new version. e.g. For WordPress 7.0, `$fonts_version` should be `wp-7.0`.
 
 ```php
-// Rewrite Google Fonts URLs to localhost.
-function my_local_google_fonts_collection( $pre, $args, $url ) {
-	$wp_release_fonts_version = '6.5';
-	$gutenberg_release_fonts_version = '17.7';
-	$generated_fonts_version = '18.2';
-
-	if ( str_starts_with( $url, 'https://s.w.org/images/fonts/' ) ) {
-		$url = str_replace( "https://s.w.org/images/fonts/wp-$wp_release_fonts_version", "http://localhost:9158/images/fonts/$generated_fonts_version", $url );
-		$url = str_replace( "https://s.w.org/images/fonts/$gutenberg_release_fonts_version", "http://localhost:9158/images/fonts/$generated_fonts_version", $url );
-		$http = new WP_Http();
-		return $http->request( $url, $args );
-	}
-
-	return $pre;
+// Register new Google Fonts font collection
+function test_new_google_fonts_font_collection() {
+	// Replace with the new version. e.g. 'wp-7.0'.
+	$fonts_version = 'wp-7.0';
+	wp_register_font_collection(
+		'new-google-fonts',
+		array(
+			'name'          => 'New Google Fonts',
+			'description'   => 'These font collections are served from a local server for testing purposes.',
+			'font_families' => 'http://localhost:9158/images/fonts/' . $fonts_version . '/collections/google-fonts-with-preview.json',
+			'categories'    => array(
+				array( 'name' => 'Sans Serif',  'slug' => 'sans-serif' ),
+				array( 'name' => 'Display',     'slug' => 'display' ),
+				array( 'name' => 'Serif',       'slug' => 'serif' ),
+				array( 'name' => 'Handwriting', 'slug' => 'handwriting' ),
+				array( 'name' => 'Monospace',   'slug' => 'monospace' ),
+			),
+		)
+	);
 }
-add_filter( 'pre_http_request', 'my_local_google_fonts_collection', 10, 3 );
+add_action( 'init', 'test_new_google_fonts_font_collection' );
 
 // Allow serving fonts locally for testing.
 function my_allow_localhost( $allow, $host, $url ) {
 	if ( str_starts_with( $url, 'http://localhost:9158/images/fonts/' ) ) {
 		$allow = true;
 	}
-
 	return $allow;
 }
 add_filter( 'http_request_host_is_external', 'my_allow_localhost', 10, 3 );
@@ -108,30 +145,46 @@ function my_allow_http_ports( $ports ) {
 add_filter( 'http_allowed_safe_ports', 'my_allow_http_ports' );
 ```
 
-The local WordPress site should now load fonts from this repo. You can check by loading the Font Library in the site editor and looking at the log output from `npm run serve`.
+This will add the new font collection to your local WordPress site. You can now access the new fonts by visiting the Appearance > Fonts menu and under the `New Google Fonts` tab.
 
-## Extra utilities
+In particular, check the following for newly added fonts:
+
+-   Is the preview displayed correctly?
+-   Is the number of variations correct?
+-   Does it install correctly?
+-   Once activated, does the font display correctly on the front-end and in the editor?
+
+You can see the list of new fonts with the following command. Remember to replace `{NEW_RELEASE}` and `{PREVIOUS_RELEASE}` with the correct version. e.g. For WordPress 7.0, `{NEW_RELEASE}` should be `wp-7.0` and `{PREVIOUS_RELEASE}` should be `wp-6.9`.
+
+```bash
+comm -23 <(jq -r '.font_families[].font_family_settings.name' releases/{NEW_RELEASE}/collections/google-fonts-with-preview.json | sort) <(jq -r '.font_families[].font_family_settings.name' releases/{PREVIOUS_RELEASE}/collections/google-fonts-with-preview.json | sort)
+```
+
+### 7. Host fonts via CDN
+
+Once the PR is merged, submit a meta ticket to host the font list on the GitHub repository, for example: [https://meta.trac.wordpress.org/ticket/8172](https://meta.trac.wordpress.org/ticket/8172)
+
+**Note: Do not access or link to the collection/preview URLs until the fonts are hosted on the CDN. The CDN caches 404 responses indefinitely, which can cause issues.**
+
+### 8. Submit a core patch
+
+Create a PR to apply the new published URL to WordPress core. Search the entire `wordpress-develop` repository for the previous URL and replace it with the new URL. e.g. For WordPress 7.0, search for `fonts/wp-6.9` and replace it with `fonts/wp-7.0`. The [Pull request #10891](https://github.com/WordPress/wordpress-develop/pull/10891) is an example of this for the WordPress 7.0 release.
+
+Also, as in [STEP 6](#6-test-the-pr), please make sure that the new fonts are working properly.
+
+-   Is the preview displayed correctly?
+-   Is the number of variations correct?
+-   Does it install correctly?
+-   Once activated, does the font display correctly on the front-end and in the editor?
+
+## Extra Utilities
 
 ### Download all the font files
 
-Downloads each one of the font assets for the 1500+ families available.
+Downloads font files for all font families and font faces listed in the Google Fonts collection JSON to the `font-assets/` directory:
 
 ```bash
 npm run files
 ```
 
-## Requirements
-
-- NodeJS 18+
-- A Google Fonts API key
-
-## Creating a new version of the font collection
-
-Update the `CURRENT_RELEASE` and `SVG_PREVIEWS_BASE_URL` constants in `src/constant.js` with the new version.
-
-- e.g. For Gutenberg 18.2, `const CURRENT_RELEASE = '18.2'` and `const SVG_PREVIEWS_BASE_URL = 'https://s.w.org/images/fonts/18.2/previews/'`
-- e.g. For WordPress 6.6,  `const CURRENT_RELEASE = 'wp-6.6'` and `const SVG_PREVIEWS_BASE_URL = 'https://s.w.org/images/fonts/wp-6.6/previews/'`
-
-Generate a new version of the collection using the commands above, generate new previews if needed, and open a PR with the change.
-
-Once the PR is merged to trunk, the collection can be uploaded to the s.wp.org CDN by submitting a meta ticket, for example: <https://meta.trac.wordpress.org/ticket/7522>
+Note that this command may take some time, as it downloads a large number of font files.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This script will create a new `releases/{wp-X.X}/collections/google-fonts.json` 
 
 ### 4. Generate SVG Previews for Google Fonts
 
-Generates SVG preview images for each font family and font face from the Google Fonts collection. The script iterates over the list of font families, downloads the font assets, uses them to generate SVG preview images, and creates a new JSON file with preview image links. The updated JSON file is saved as `releases/{wp-X.X}/collections/google-fonts-with-preview.json`.
+Generate SVG preview images for each font family and font face from the Google Fonts collection. The script below iterates over the list of font families, downloads the font assets, uses them to generate SVG preview images, and creates a new JSON file with preview image links. The updated JSON file is saved as `releases/{wp-X.X}/collections/google-fonts-with-preview.json`.
 
 ```bash
 npm run previews

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If the font preview fails to generate due to a possibly corrupted font, consider
 
 ### 5. Create a PR
 
-Now you're ready to create a pull request. The modified files/directory should look like this, commit them, and submit the PR:
+Now you're ready to create a pull request. The modified files/directory should look like this. Commit these changes, and submit the PR:
 
 -   Modifiled:
     -   `src/constants.js`


### PR DESCRIPTION
With each major WordPress release, a new font collection needs to be generated, hosted, and the core source updated.

However, current documentation is insufficient, and it's not something anyone can do. Let's create clear documentation so this work doesn't become a one-person job.

https://github.com/WordPress/google-fonts-to-wordpress-collection/blob/docs/update-release-tasks/README.md#creating-a-new-version-of-the-font-collection