### PR TITLE
Document enabling the Web Fonts Developer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First, Update the `CURRENT_RELEASE` and `SVG_PREVIEWS_BASE_URL` constants in `sr
 
 ### 3. Fetch Google Fonts Data
 
-Fetches font data from the Google Fonts API and converts it to a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections. Create a Google API key on [the credentials page](https://console.cloud.google.com/apis/credentials) and set it as the `GOOGLE_FONTS_API_KEY` environment variable:
+Fetches font data from the Google Fonts API and converts it to a WordPress `theme.json` like format to be compatible with the new WordPress Font Library collections. Create a Google API key on [the credentials page](https://console.cloud.google.com/apis/credentials), enable the Web Fonts Developer API for that project, and set it as the `GOOGLE_FONTS_API_KEY` environment variable:
 
 ```bash
 GOOGLE_FONTS_API_KEY={YOUR_GOOGLE_FONTS_API_KEY} npm run api


### PR DESCRIPTION
## What

Documents that the **Web Fonts Developer API** must be enabled on the Google Cloud project before running `npm run api`.

## Why

An API key alone is not enough to fetch data from the Google Fonts API. If the Web Fonts Developer API is not enabled for the project that owns the key, the fetch step fails. The README did not mention this requirement, leading to confusion during setup.

## How

Adds the enablement instruction to the "3. Fetch Google Fonts Data" step in the README.
